### PR TITLE
🐛 fix static site generation for single-language sites

### DIFF
--- a/class.php
+++ b/class.php
@@ -99,7 +99,7 @@ class StaticSiteGenerator
   protected function _generatePage(Page $page, string $path, string $baseUrl)
   {
     $html = $page->render();
-    $html = str_replace("$this->_originalBaseUrl/", $baseUrl, $html);
+    $html = str_replace($this->_originalBaseUrl . '/', $baseUrl, $html);
     $html = str_replace($this->_originalBaseUrl, $baseUrl, $html);
 
     F::write($path, $html);

--- a/class.php
+++ b/class.php
@@ -63,12 +63,11 @@ class StaticSiteGenerator
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
     $this->_setPageLanguage($homePage, $this->_defaultLanguage);
-    $this->_generatePage($homePage, $this->_outputFolder . DS . 'index.html');
+    $this->_generatePage($homePage, $this->_outputFolder . DS . 'index.html', $baseUrl);
 
     foreach ($this->_languages as $languageCode) {
       $this->_generatePagesByLanguage($baseUrl, $languageCode);
     }
-
     $this->_copyMediaFiles($baseUrl);
 
     StaticSiteGeneratorMedia::setActive(false);
@@ -86,7 +85,7 @@ class StaticSiteGenerator
       $path = str_replace($baseUrl, '/', $page->url());
       $path = str_replace('//', '/', $path);
       $path = $this->_outputFolder . str_replace('/', DS, $path) . DS . 'index.html';
-      $this->_generatePage($page, $path);
+      $this->_generatePage($page, $path, $baseUrl);
     }
   }
 
@@ -102,9 +101,12 @@ class StaticSiteGenerator
     $kirby->site()->visit($page, $languageCode);
   }
 
-  protected function _generatePage(Page $page, string $path)
+  protected function _generatePage(Page $page, string $path, string $baseUrl)
   {
+    $originalBaseUrl = $this->_originalUrls['base'];
     $html = $page->render();
+    $html = str_replace("$originalBaseUrl/", $baseUrl, $html);
+    $html = str_replace($originalBaseUrl, $baseUrl, $html);
     F::write($path, $html);
 
     $this->_fileList = array_unique(array_merge($this->_fileList, [$path]));
@@ -208,7 +210,7 @@ class StaticSiteGenerator
     $mediaUrl = str_replace('//', '/', $mediaUrl);
 
     $this->_modifyUrl('index', $baseUrl);
-    $this->_modifyUrl('base', $baseUrl);
+    $this->_modifyUrl('base', '');
     $this->_modifyUrl('media', $mediaUrl);
 
     $urlKeys = array_keys($this->_originalUrls);

--- a/class.php
+++ b/class.php
@@ -1,12 +1,10 @@
 <?php
 namespace D4L;
 
-use Closure;
 use Dir;
 use Error;
 use F;
 use Kirby\Cms\App;
-use Kirby\Cms\Ingredients;
 use Kirby\Cms\Page;
 
 
@@ -16,11 +14,10 @@ class StaticSiteGenerator
   protected $_pathsToCopy;
   protected $_outputFolder;
 
-  protected $_originalUrls = [];
-
   protected $_pages;
   protected $_fileList = [];
 
+  protected $_originalBaseUrl;
   protected $_defaultLanguage;
   protected $_languages;
 
@@ -32,9 +29,9 @@ class StaticSiteGenerator
     $this->_pathsToCopy = $this->_resolveRelativePaths($this->_pathsToCopy);
     $this->_outputFolder = $this->_resolveRelativePath('./static');
 
-    $this->_originalUrls = $kirby->urls()->toArray();
     $this->_pages = $kirby->site()->index();
 
+    $this->_originalBaseUrl = $kirby->urls()->base();
     $this->_defaultLanguage = $kirby->languages()->default();
     $this->_languages = $this->_defaultLanguage ? $kirby->languages()->keys() : [$this->_defaultLanguage];
   }
@@ -57,8 +54,7 @@ class StaticSiteGenerator
 
   public function generatePages(string $baseUrl = '/')
   {
-    $baseUrl = rtrim($baseUrl, '/') ?: '/';
-    $this->_modifyUrls($baseUrl);
+    $baseUrl = rtrim($baseUrl, '/') . '/';
     StaticSiteGeneratorMedia::setActive(true);
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
@@ -68,11 +64,10 @@ class StaticSiteGenerator
     foreach ($this->_languages as $languageCode) {
       $this->_generatePagesByLanguage($baseUrl, $languageCode);
     }
-    $this->_copyMediaFiles($baseUrl);
+    $this->_copyMediaFiles();
 
     StaticSiteGeneratorMedia::setActive(false);
     StaticSiteGeneratorMedia::clearList();
-    $this->_restoreUrls();
 
     return $this->_fileList;
   }
@@ -82,7 +77,7 @@ class StaticSiteGenerator
     foreach ($this->_pages->keys() as $key) {
       $page = $this->_pages->$key;
       $this->_setPageLanguage($page, $languageCode);
-      $path = str_replace($baseUrl, '/', $page->url());
+      $path = str_replace($this->_originalBaseUrl, '/', $page->url());
       $path = str_replace('//', '/', $path);
       $path = $this->_outputFolder . str_replace('/', DS, $path) . DS . 'index.html';
       $this->_generatePage($page, $path, $baseUrl);
@@ -103,10 +98,10 @@ class StaticSiteGenerator
 
   protected function _generatePage(Page $page, string $path, string $baseUrl)
   {
-    $originalBaseUrl = $this->_originalUrls['base'];
     $html = $page->render();
-    $html = str_replace("$originalBaseUrl/", $baseUrl, $html);
-    $html = str_replace($originalBaseUrl, $baseUrl, $html);
+    $html = str_replace("$this->_originalBaseUrl/", $baseUrl, $html);
+    $html = str_replace($this->_originalBaseUrl, $baseUrl, $html);
+
     F::write($path, $html);
 
     $this->_fileList = array_unique(array_merge($this->_fileList, [$path]));
@@ -137,14 +132,14 @@ class StaticSiteGenerator
     return $this->_fileList;
   }
 
-  protected function _copyMediaFiles(string $baseUrl = '/')
+  protected function _copyMediaFiles()
   {
     $outputFolder = $this->_outputFolder;
     $mediaList = StaticSiteGeneratorMedia::getList();
 
     foreach ($mediaList as $item) {
       $file = $item['root'];
-      $path = str_replace($baseUrl, '/', $item['url']);
+      $path = str_replace($this->_originalBaseUrl, '/', $item['url']);
       $path = str_replace('//', '/', $path);
       $path =  $outputFolder . str_replace('/', DS, $path);
       $this->_copyFile($file, $path);
@@ -203,59 +198,6 @@ class StaticSiteGenerator
     }, []) ?: [];
   }
 
-  protected function _modifyUrls(string $baseUrl)
-  {
-    $originalBaseUrl = $this->_kirby->urls()->base();
-    $mediaUrl = $baseUrl . str_replace($originalBaseUrl, '', $this->_kirby->urls()->media());
-    $mediaUrl = str_replace('//', '/', $mediaUrl);
-
-    $this->_modifyUrl('index', $baseUrl);
-    $this->_modifyUrl('base', '');
-    $this->_modifyUrl('media', $mediaUrl);
-
-    $urlKeys = array_keys($this->_originalUrls);
-    foreach ($this->_kirby->roots()->toArray() as $key => $root) {
-      if (in_array($root, $this->_pathsToCopy) && in_array($key, $urlKeys)) {
-        $folderName = $this->_getFolderName($root);
-        $this->_modifyUrl($key, $baseUrl . '/' . $folderName);
-      }
-    }
-  }
-
-  protected function _modifyUrl(string $property, string $url)
-  {
-    $url = str_replace('//', '/', $url);
-    $setUrl = $this->_getUrlSetter();
-    $setUrl($this->_kirby, $property, $url);
-  }
-
-  protected function _restoreUrls()
-  {
-    $urls = $this->_kirby->urls();
-    foreach ($this->_originalUrls as $key => $originalUrl) {
-      if ($originalUrl !== $urls->$key()) {
-        $this->_restoreUrl($key);
-      }
-    }
-  }
-
-  protected function _restoreUrl(string $property)
-  {
-    if (isset($this->_originalUrls[$property])) {
-      $setUrl = $this->_getUrlSetter();
-      $setUrl($this->_kirby, $property, $this->_originalUrls[$property]);
-    }
-  }
-
-  protected function _getUrlSetter()
-  {
-    return Closure::bind(function (App $kirby, string $property, string $value) {
-      $urls = $kirby->urls->toArray();
-      $urls[$property] = $value;
-      return $kirby->urls = new Ingredients($urls);
-    }, null, 'Kirby\Cms\App');
-  }
-
   protected function _resolveRelativePaths(array $paths)
   {
     return array_values(array_filter(array_map(function ($path) {
@@ -273,4 +215,3 @@ class StaticSiteGenerator
     return realpath($path) ?: $path;
   }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
Fix static site generation for setups without enabled multi-language feature

## Description

This plugin was tested in a multi-language site setup, but never in a setup without enabled multi-lang feature. When testing it with the [starterkit](https://github.com/getkirby/starterkit) without languages, it threw an error because `$kirby->languages()->default()` and `$kirby->language()` are `NULL`.

## Motivation

Fixing the plugin for setups without multi-lang feature.

## Testing

Generating through the panel field was tested both with and without multi-lang feature with 0 - 3 languages. Result: Base URL had to be fixed

## Related issue

--
