### PR TITLE
🐛 fix generation when default language is null

### DIFF
--- a/class.php
+++ b/class.php
@@ -58,7 +58,7 @@ class StaticSiteGenerator
     StaticSiteGeneratorMedia::setActive(true);
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
-    $this->_setPageLanguage($homePage, $this->_defaultLanguage->code());
+    $this->_setPageLanguage($homePage, $this->_defaultLanguage ? $this->_defaultLanguage->code() : null);
     $this->_generatePage($homePage, $this->_outputFolder . DS . 'index.html', $baseUrl);
 
     foreach ($this->_languages as $languageCode) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
`$kirby->languages()->default()` used to return an object even in case of a single-language site. This was changed recently and now `null` is returned instead, leading to https://github.com/d4l-data4life/kirby3-static-site-generator/issues/12

## Related issue
https://github.com/d4l-data4life/kirby3-static-site-generator/issues/12
