### PR TITLE
✨ handle render errors: show context more verbosely

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,11 @@ panel.plugin('d4l/static-site-generator', {
       `,
       methods: {
         async execute() {
-          const { config } = this.$api;
           const { endpoint } = this.$props;
+          if (!endpoint) {
+            throw new Error('Error: Config option "d4l.static_site_generator.endpoint" is missing or null. Please set this to any string, e.g. "generate-static-site".');
+          }
+
           this.isBusy = true;
           const response = await this.$api.post(`${endpoint}`);
           this.isBusy = false;


### PR DESCRIPTION
before:
![grafik](https://user-images.githubusercontent.com/8958624/61323901-6a217a00-a811-11e9-8d1c-19ef8fb1f39c.png)

after:
![grafik](https://user-images.githubusercontent.com/8958624/61323850-4a8a5180-a811-11e9-8062-e97fc5533845.png)
