### PR TITLE
🔒output folder check; ✨ preserve root-level files starting with dot; ✨ add preserve config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $fileList = $staticSiteGenerator->generate($outputFolder = './static', $baseUrl 
 ```
 
 - `$pathsToCopy`: if not given, `$kirby->roots()->assets()` is used; set to `[]` to skip copying other files than media
-- use `$preserve` to preserve individual files or folders in your output folder, e.g. if the folder is a git repository, set `$preserve`to `['.git']`; also useful to preserve for example a favicon directly in the root of the output folder
+- use `$preserve` to preserve individual files or folders in your output folder, e.g. if you want to preserve a `README.md` in your output folder, set `$preserve`to `['README.md']`; any files or folders directly in the root level and starting with `.` are always preserved (e.g. `.git`)
 
 ### 2) By triggering an endpoint
 
@@ -68,9 +68,10 @@ fields:
 return [
     'd4l' => [
       'static_site_generator' => [
-        'endpoint' => null, # set to a string to use the built-in webhook, e.g. when using the blueprint field
+        'endpoint' => null, # set to any string like 'generate-static-site' to use the built-in endpoint (necessary when using the blueprint field)
         'output_folder' => './static', # you can specify an absolute or relative path
-        'base_url' => '/', # if the static site is not mounted to the root folder of your domain, change accordingly here
+        'preserve' => [], # preserve individual files / folders in the root level of the output folder (anything starting with "." is always preserved)
+        'base_url' => '/' # if the static site is not mounted to the root folder of your domain, change accordingly here
       ]
     ]
 ];
@@ -91,7 +92,7 @@ error: Custom error message
 
 ## Warnings
 
-Be very careful when specifying the output folder, as the given path will be erased before the generation!
+Be careful when specifying the output folder, as the given path (except files starting with `.`) will be erased before the generation! There is a safety check in place to avoid accidental erasure when specifying existing, non-empty folders.
 
 ## Contribute
 

--- a/class.php
+++ b/class.php
@@ -253,7 +253,7 @@ class StaticSiteGenerator
       'Hello! It seems the given output folder "' . $folder . '" already contains other files or folders. ' .
         'Please specify a path that does not exist yet, or is empty. If it absolutely has to be this path, create ' .
         'an empty .kirbystatic file and retry. WARNING: Any contents of the output folder not starting with "." ' .
-        'are ERASED before generation! Information on preserving individual files and folders can be found in the Readme.'
+        'are erased before generation! Information on preserving individual files and folders can be found in the Readme.'
     );
   }
 

--- a/class.php
+++ b/class.php
@@ -42,6 +42,7 @@ class StaticSiteGenerator
   {
     $this->_outputFolder = $this->_resolveRelativePath($outputFolder ?: $this->_outputFolder);
     $this->_checkOutputFolder();
+    F::write($this->_outputFolder . '/.kirbystatic', '');
 
     $this->clearFolder($this->_outputFolder, $preserve);
     $this->generatePages($baseUrl);
@@ -232,26 +233,26 @@ class StaticSiteGenerator
       throw new Error('Error: Please specify a valid output folder!');
     }
 
-    if (!Dir::isWritable($folder)) {
-      throw new Error('Error: The output folder is not writable');
-    }
-
     if (Dir::isEmpty($folder)) {
       return;
+    }
+
+    if (!Dir::isWritable($folder)) {
+      throw new Error('Error: The output folder is not writable');
     }
 
     $fileList = array_map(function ($path) use ($folder) {
       return str_replace($folder . '/', '', $path);
     }, $this->_getFileList($folder));
 
-    if (in_array('index.html', $fileList)) {
+    if (in_array('index.html', $fileList) || in_array('.kirbystatic', $fileList)) {
       return;
     }
 
     throw new Error(
       'Hello! It seems the given output folder "' . $folder . '" already contains other files or folders. ' .
         'Please specify a path that does not exist yet, or is empty. If it absolutely has to be this path, create ' .
-        'an index.html file (can be empty) and retry. WARNING: Any contents of the output folder not starting with "." ' .
+        'an empty .kirbystatic file and retry. WARNING: Any contents of the output folder not starting with "." ' .
         'are ERASED before generation! Information on preserving individual files and folders can be found in the Readme.'
     );
   }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace D4L;
 
 use Kirby;
@@ -21,9 +22,10 @@ Kirby::plugin('d4l/static-site-generator', [
           'action' => function () use ($kirby) {
             $outputFolder = $kirby->option('d4l.static_site_generator.output_folder', './static');
             $baseUrl = $kirby->option('d4l.static_site_generator.base_url', '/');
+            $preserve = $kirby->option('d4l.static_site_generator.preserve', []);
 
             $staticSiteGenerator = new StaticSiteGenerator($kirby);
-            $list = $staticSiteGenerator->generate($outputFolder, $baseUrl);
+            $list = $staticSiteGenerator->generate($outputFolder, $baseUrl, $preserve);
             $count = count($list);
             return ['success' => true, 'files' => $list, 'message' => "$count files generated / copied"];
           },


### PR DESCRIPTION
see https://github.com/d4l-data4life/kirby3-static-site-generator/issues/9
(security check against accidental erasure of output folder when wrongly specified)
The very verbose error message looks like this:
![image](https://user-images.githubusercontent.com/8958624/61789714-ac504a00-ae15-11e9-9eee-e0d167a0afce.png)

Also, always preserve root-level files/folders in the output folder when starting with `.`
Very often these are files or folders like `.git`, which one wants to preserve anyway.

Additionally, make it possible to preserve individual files and folders when using the field via blueprint, by adding support for a config option: `d4l.static_site_generator.preserve`
