### PR TITLE
🐛 reset file content cache

### DIFF
--- a/class.php
+++ b/class.php
@@ -93,6 +93,10 @@ class StaticSiteGenerator
   {
     foreach ($this->_pages as $page) {
       $page->content = null;
+
+      foreach ($page->files() as $file) {
+        $file->content = null;
+      }
     }
 
     $kirby = $this->_kirby;

--- a/class.php
+++ b/class.php
@@ -92,7 +92,8 @@ class StaticSiteGenerator
   protected function _setPageLanguage(Page $page, string $languageCode = null)
   {
     $kirby = $this->_kirby;
-    $pages = $kirby->site()->index();
+    $site = $kirby->site();
+    $pages = $site->index();
 
     foreach ($pages as $page) {
       $page->content = null;
@@ -101,13 +102,13 @@ class StaticSiteGenerator
       }
     }
 
-    $kirby->site()->content = null;
-    foreach ($kirby->site()->files() as $file) {
+    $site->content = null;
+    foreach ($site->files() as $file) {
       $file->content = null;
     }
 
     $kirby->cache('pages')->flush();
-    $kirby->site()->visit($page, $languageCode);
+    $site->visit($page, $languageCode);
   }
 
   protected function _generatePage(Page $page, string $path, string $baseUrl)

--- a/class.php
+++ b/class.php
@@ -91,17 +91,22 @@ class StaticSiteGenerator
 
   protected function _setPageLanguage(Page $page, string $languageCode = null)
   {
-    foreach ($this->_pages as $page) {
-      $page->content = null;
+    $kirby = $this->_kirby;
+    $pages = $kirby->site()->index();
 
+    foreach ($pages as $page) {
+      $page->content = null;
       foreach ($page->files() as $file) {
         $file->content = null;
       }
     }
 
-    $kirby = $this->_kirby;
-    $kirby->cache('pages')->flush();
     $kirby->site()->content = null;
+    foreach ($kirby->site()->files() as $file) {
+      $file->content = null;
+    }
+
+    $kirby->cache('pages')->flush();
     $kirby->site()->visit($page, $languageCode);
   }
 


### PR DESCRIPTION
fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/16

In Kirby multi-language setups, rendering the same page in different languages in succession (in the same request) leads to unexpected results, because the `content` property of the page and its files is already populated. This was fixed previously for pages, but not for files.
