### PR TITLE
✨ add option to skip copying media files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ return [
         'endpoint' => null, # set to any string like 'generate-static-site' to use the built-in endpoint (necessary when using the blueprint field)
         'output_folder' => './static', # you can specify an absolute or relative path
         'preserve' => [], # preserve individual files / folders in the root level of the output folder (anything starting with "." is always preserved)
-        'base_url' => '/' # if the static site is not mounted to the root folder of your domain, change accordingly here
+        'base_url' => '/', # if the static site is not mounted to the root folder of your domain, change accordingly here
+        'skip_media' => false # set to true to skip copying media files, e.g. when it is on a CDN; combinable with 'preserve' => ['media']
       ]
     ]
 ];
@@ -79,6 +80,7 @@ return [
 
 All of these options are only relevant if you use implementation options 2) or 3).
 When directly using the `D4L\StaticSiteGenerator` class, no config options are required.
+In that case, options like `skip_media` can be achieved by calling `$staticSiteGenerator->skipMedia(true)`.
 
 ## Field options
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ return [
         'output_folder' => './static', # you can specify an absolute or relative path
         'preserve' => [], # preserve individual files / folders in the root level of the output folder (anything starting with "." is always preserved)
         'base_url' => '/', # if the static site is not mounted to the root folder of your domain, change accordingly here
-        'skip_media' => false # set to true to skip copying media files, e.g. when it is on a CDN; combinable with 'preserve' => ['media']
+        'skip_media' => false # set to true to skip copying media files, e.g. when they are already on a CDN; combinable with 'preserve' => ['media']
       ]
     ]
 ];

--- a/class.php
+++ b/class.php
@@ -23,6 +23,8 @@ class StaticSiteGenerator
   protected $_defaultLanguage;
   protected $_languages;
 
+  protected $_skipCopyingMedia = false;
+
   public function __construct(App $kirby, array $pathsToCopy = null)
   {
     $this->_kirby = $kirby;
@@ -56,7 +58,9 @@ class StaticSiteGenerator
   public function generatePages(string $baseUrl = '/')
   {
     $baseUrl = rtrim($baseUrl, '/') . '/';
-    StaticSiteGeneratorMedia::setActive(true);
+
+    $copyMedia = !$this->_skipCopyingMedia;
+    $copyMedia && StaticSiteGeneratorMedia::setActive(true);
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
     $this->_setPageLanguage($homePage, $this->_defaultLanguage ? $this->_defaultLanguage->code() : null);
@@ -65,12 +69,20 @@ class StaticSiteGenerator
     foreach ($this->_languages as $languageCode) {
       $this->_generatePagesByLanguage($baseUrl, $languageCode);
     }
-    $this->_copyMediaFiles();
 
-    StaticSiteGeneratorMedia::setActive(false);
-    StaticSiteGeneratorMedia::clearList();
+    if ($copyMedia) {
+      $this->_copyMediaFiles();
+
+      StaticSiteGeneratorMedia::setActive(false);
+      StaticSiteGeneratorMedia::clearList();
+    }
 
     return $this->_fileList;
+  }
+
+  public function skipMedia($skipCopyingMedia = true)
+  {
+    $this->_skipCopyingMedia = $skipCopyingMedia;
   }
 
   protected function _generatePagesByLanguage(string $baseUrl, string $languageCode = null)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -23,8 +23,10 @@ Kirby::plugin('d4l/static-site-generator', [
             $outputFolder = $kirby->option('d4l.static_site_generator.output_folder', './static');
             $baseUrl = $kirby->option('d4l.static_site_generator.base_url', '/');
             $preserve = $kirby->option('d4l.static_site_generator.preserve', []);
+            $skipMedia = $kirby->option('d4l.static_site_generator.skip_media', false);
 
             $staticSiteGenerator = new StaticSiteGenerator($kirby);
+            $staticSiteGenerator->skipMedia($skipMedia);
             $list = $staticSiteGenerator->generate($outputFolder, $baseUrl, $preserve);
             $count = count($list);
             return ['success' => true, 'files' => $list, 'message' => "$count files generated / copied"];


### PR DESCRIPTION
see https://github.com/d4l-data4life/kirby3-static-site-generator/issues/10

On sites with a lot of media files, not copying these files every time can be a desirable option.
This is also handy when the media resides on a CDN and the images stored by Kirby are just a reference.

This PR adds a `skip_media` config option as well as a public `skipMedia` method to the class.