### PR TITLE
✨ add option to skip pages or templates from being generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Alternatively, create a `static-site-generator` folder in `site/plugins`, downlo
 ### 1) Directly (e.g. from a kirby hook)
 
 ```php
-$staticSiteGenerator = new D4L\StaticSiteGenerator($kirby, $pathsToCopy = null);
+$staticSiteGenerator = new D4L\StaticSiteGenerator($kirby, $pathsToCopy = null, $pages = null);
 $fileList = $staticSiteGenerator->generate($outputFolder = './static', $baseUrl = '/', $preserve = []);
 ```
 
 - `$pathsToCopy`: if not given, `$kirby->roots()->assets()` is used; set to `[]` to skip copying other files than media
+- `$pages`: if not given, all pages are rendered
 - use `$preserve` to preserve individual files or folders in your output folder, e.g. if you want to preserve a `README.md` in your output folder, set `$preserve`to `['README.md']`; any files or folders directly in the root level and starting with `.` are always preserved (e.g. `.git`)
 
 ### 2) By triggering an endpoint
@@ -72,7 +73,8 @@ return [
         'output_folder' => './static', # you can specify an absolute or relative path
         'preserve' => [], # preserve individual files / folders in the root level of the output folder (anything starting with "." is always preserved)
         'base_url' => '/', # if the static site is not mounted to the root folder of your domain, change accordingly here
-        'skip_media' => false # set to true to skip copying media files, e.g. when they are already on a CDN; combinable with 'preserve' => ['media']
+        'skip_media' => false, # set to true to skip copying media files, e.g. when they are already on a CDN; combinable with 'preserve' => ['media']
+        'skip_templates' => [] # ignore pages with given templates (home is always rendered)
       ]
     ]
 ];

--- a/class.php
+++ b/class.php
@@ -7,6 +7,7 @@ use Error;
 use F;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
 use Whoops\Exception\ErrorException;
 
 
@@ -25,7 +26,7 @@ class StaticSiteGenerator
 
   protected $_skipCopyingMedia = false;
 
-  public function __construct(App $kirby, array $pathsToCopy = null)
+  public function __construct(App $kirby, array $pathsToCopy = null, Pages $pages = null)
   {
     $this->_kirby = $kirby;
 
@@ -33,7 +34,7 @@ class StaticSiteGenerator
     $this->_pathsToCopy = $this->_resolveRelativePaths($this->_pathsToCopy);
     $this->_outputFolder = $this->_resolveRelativePath('./static');
 
-    $this->_pages = $kirby->site()->index();
+    $this->_pages = $pages ?: $kirby->site()->index();
 
     $this->_originalBaseUrl = $kirby->urls()->base();
     $this->_defaultLanguage = $kirby->languages()->default();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -24,8 +24,10 @@ Kirby::plugin('d4l/static-site-generator', [
             $baseUrl = $kirby->option('d4l.static_site_generator.base_url', '/');
             $preserve = $kirby->option('d4l.static_site_generator.preserve', []);
             $skipMedia = $kirby->option('d4l.static_site_generator.skip_media', false);
+            $skipTemplates = array_diff($kirby->option('d4l.static_site_generator.skip_templates', []), ['home']);
 
-            $staticSiteGenerator = new StaticSiteGenerator($kirby);
+            $pages = $kirby->site()->index()->filterBy('intendedTemplate', 'not in', $skipTemplates);
+            $staticSiteGenerator = new StaticSiteGenerator($kirby, null, $pages);
             $staticSiteGenerator->skipMedia($skipMedia);
             $list = $staticSiteGenerator->generate($outputFolder, $baseUrl, $preserve);
             $count = count($list);


### PR DESCRIPTION
see https://github.com/d4l-data4life/kirby3-static-site-generator/issues/11

It is not always desired to generate all pages. Some pages might for example only be used as a resource for other pages, and not as a standalone page.

This PR adds an option to
- define which pages to be rendered when using the class directly
- an option to skip/filter certain templates/blueprints when using the endpoint/field