### PR TITLE
✨🐛 add Windows support

### DIFF
--- a/class.php
+++ b/class.php
@@ -65,7 +65,7 @@ class StaticSiteGenerator
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
     $this->_setPageLanguage($homePage, $this->_defaultLanguage ? $this->_defaultLanguage->code() : null);
-    $this->_generatePage($homePage, $this->_outputFolder . DIRECTORY_SEPARATOR . 'index.html', $baseUrl);
+    $this->_generatePage($homePage, $this->_outputFolder . '/index.html', $baseUrl);
 
     foreach ($this->_languages as $languageCode) {
       $this->_generatePagesByLanguage($baseUrl, $languageCode);
@@ -93,7 +93,7 @@ class StaticSiteGenerator
       $this->_setPageLanguage($page, $languageCode);
       $path = str_replace($this->_originalBaseUrl, '/', $page->url());
       $path = str_replace('//', '/', $path);
-      $path = $this->_outputFolder . str_replace('/', DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . 'index.html';
+      $path = $this->_outputFolder . $path . '/index.html';
       try {
         $this->_generatePage($page, $path, $baseUrl);
       } catch (ErrorException $error) {
@@ -149,7 +149,7 @@ class StaticSiteGenerator
     }
 
     $folderName = $this->_getFolderName($folder);
-    $targetPath = $outputFolder . DIRECTORY_SEPARATOR . $folderName;
+    $targetPath = $outputFolder . DS . $folderName;
 
     if (is_file($folder)) {
       return $this->_copyFile($folder, $targetPath);
@@ -174,7 +174,7 @@ class StaticSiteGenerator
       $file = $item['root'];
       $path = str_replace($this->_originalBaseUrl, '/', $item['url']);
       $path = str_replace('//', '/', $path);
-      $path =  $outputFolder . str_replace('/', DIRECTORY_SEPARATOR, $path);
+      $path =  $outputFolder . $path;
       $this->_copyFile($file, $path);
     }
 
@@ -245,7 +245,7 @@ class StaticSiteGenerator
       return realpath($path) ?: $path;
     }
 
-    $path = $this->_kirby->roots()->index() . DIRECTORY_SEPARATOR . $path;
+    $path = $this->_kirby->roots()->index() . DS . $path;
     return realpath($path) ?: $path;
   }
 

--- a/class.php
+++ b/class.php
@@ -65,7 +65,7 @@ class StaticSiteGenerator
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
     $this->_setPageLanguage($homePage, $this->_defaultLanguage ? $this->_defaultLanguage->code() : null);
-    $this->_generatePage($homePage, $this->_outputFolder . DS . 'index.html', $baseUrl);
+    $this->_generatePage($homePage, $this->_outputFolder . DIRECTORY_SEPARATOR . 'index.html', $baseUrl);
 
     foreach ($this->_languages as $languageCode) {
       $this->_generatePagesByLanguage($baseUrl, $languageCode);
@@ -93,7 +93,7 @@ class StaticSiteGenerator
       $this->_setPageLanguage($page, $languageCode);
       $path = str_replace($this->_originalBaseUrl, '/', $page->url());
       $path = str_replace('//', '/', $path);
-      $path = $this->_outputFolder . str_replace('/', DS, $path) . DS . 'index.html';
+      $path = $this->_outputFolder . str_replace('/', DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . 'index.html';
       try {
         $this->_generatePage($page, $path, $baseUrl);
       } catch (ErrorException $error) {
@@ -149,7 +149,7 @@ class StaticSiteGenerator
     }
 
     $folderName = $this->_getFolderName($folder);
-    $targetPath = $outputFolder . DS . $folderName;
+    $targetPath = $outputFolder . DIRECTORY_SEPARATOR . $folderName;
 
     if (is_file($folder)) {
       return $this->_copyFile($folder, $targetPath);
@@ -174,7 +174,7 @@ class StaticSiteGenerator
       $file = $item['root'];
       $path = str_replace($this->_originalBaseUrl, '/', $item['url']);
       $path = str_replace('//', '/', $path);
-      $path =  $outputFolder . str_replace('/', DS, $path);
+      $path =  $outputFolder . str_replace('/', DIRECTORY_SEPARATOR, $path);
       $this->_copyFile($file, $path);
     }
 
@@ -212,7 +212,7 @@ class StaticSiteGenerator
 
   protected function _getFolderName(string $folder)
   {
-    $segments = explode(DS, $folder);
+    $segments = explode(DIRECTORY_SEPARATOR, $folder);
     return array_pop($segments);
   }
 
@@ -245,7 +245,7 @@ class StaticSiteGenerator
       return realpath($path) ?: $path;
     }
 
-    $path = $this->_kirby->roots()->index() . DS . $path;
+    $path = $this->_kirby->roots()->index() . DIRECTORY_SEPARATOR . $path;
     return realpath($path) ?: $path;
   }
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -4,8 +4,8 @@ namespace D4L;
 
 use Kirby;
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'media.class.php';
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'class.php';
+require_once __DIR__ . '/media.class.php';
+require_once __DIR__ . '/class.php';
 
 
 Kirby::plugin('d4l/static-site-generator', [

--- a/index.php
+++ b/index.php
@@ -4,8 +4,8 @@ namespace D4L;
 
 use Kirby;
 
-require_once __DIR__ . DS . 'media.class.php';
-require_once __DIR__ . DS . 'class.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'media.class.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'class.php';
 
 
 Kirby::plugin('d4l/static-site-generator', [


### PR DESCRIPTION
## Description

Contrary to the name, Kirby's `DS` is always `'/'` instead of a short form of `DIRECTORY_SEPARATOR`. This leads to path resolution bugs in Windows in `_getFolderName`. This PR removes all `DS` occurrences except for the one in `_getFolderName`, which is replaced with `DIRECTORY_SEPARATOR`.

## Motivation

https://forum.getkirby.com/t/static-site-generator-plugin/14568/6

## Testing

The change has been tested in Linux and Windows.