### PR TITLE
✨🐛 add support for case where there's no home page

### DIFF
--- a/class.php
+++ b/class.php
@@ -2,12 +2,12 @@
 
 namespace D4L;
 
-use Dir;
 use Error;
-use F;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
+use Kirby\Toolkit\Dir;
+use Kirby\Toolkit\F;
 use Whoops\Exception\ErrorException;
 
 
@@ -64,8 +64,10 @@ class StaticSiteGenerator
     $copyMedia && StaticSiteGeneratorMedia::setActive(true);
 
     $homePage = $this->_pages->findBy('isHomePage', 'true');
-    $this->_setPageLanguage($homePage, $this->_defaultLanguage ? $this->_defaultLanguage->code() : null);
-    $this->_generatePage($homePage, $this->_outputFolder . '/index.html', $baseUrl);
+    if ($homePage) {
+      $this->_setPageLanguage($homePage, $this->_defaultLanguage ? $this->_defaultLanguage->code() : null);
+      $this->_generatePage($homePage, $this->_outputFolder . '/index.html', $baseUrl);
+    }
 
     foreach ($this->_languages as $languageCode) {
       $this->_generatePagesByLanguage($baseUrl, $languageCode);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
One does not necessarily have to have the home page in the set of pages to be generated.
Currently, when there's no home page, the static site generation fails with the following output:
```
Argument 1 passed to D4L\StaticSiteGenerator::_setPageLanguage() must be an instance of Kirby\Cms\Page, null given, called in class.php on line 67
```
This is fixed with this PR.

## Description

This checks if there's a homepage, and only if so it generates the html for `/index.html`.
