### PR TITLE
🔧  Calling non-static method non-statically

### DIFF
--- a/media.class.php
+++ b/media.class.php
@@ -4,8 +4,8 @@ namespace D4L;
 
 use Kirby;
 
-$versionFn = Kirby::component('file::version');
-$urlFn = Kirby::component('file::url');
+$versionFn = (new Kirby)->component('file::version');
+$urlFn = (new Kirby)->component('file::url');
 
 
 Kirby::plugin('d4l/static-site-generator-media', [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!--- Please write a short summary of your changes here -->

## Description

When upgraded Kirby to 3.4.x, it ran into this error: 
![Screenshot 2020-08-05 at 11 18 52](https://user-images.githubusercontent.com/53568912/89396710-2c8ada00-d70f-11ea-9aae-f73ffe3dea8d.png)

This change will call these methods non-statically (Based on this [answer on SO](https://stackoverflow.com/a/19694064)).

## Motivation

It got Kirby working 🙂

## Testing

no tests done 🙈

## Related issue

none.
