### PR TITLE
Non static method `component` shouldn't be called statically

### DIFF
--- a/media.class.php
+++ b/media.class.php
@@ -2,10 +2,10 @@
 
 namespace D4L;
 
-use Kirby;
+use Kirby\Cms\App as Kirby;
 
-$versionFn = Kirby::component('file::version');
-$urlFn = Kirby::component('file::url');
+$versionFn = kirby()->component('file::version');
+$urlFn = kirby()->component('file::url');
 
 
 Kirby::plugin('d4l/static-site-generator-media', [


### PR DESCRIPTION
## Description

The current version of this plugin breaks in modern PHP setups, since the non static method `component` should not be called statically.

```diff
-$versionFn = Kirby::component('file::version');
-$urlFn = Kirby::component('file::url');
+$versionFn = kirby()->component('file::version');
+$urlFn = kirby()->component('file::url');
```

I've also fixed the Kirby app namespace use.

## Motivation

The plugin breaks with an error code and thus generates no static pages.

## Testing

Up'n running in my [kirby-modern](https://github.com/johannschopplich/kirby-modern) boilerplate.
