### PR TITLE
⚡️ improve rebuild performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 
 namespace D4L;
 
-use Kirby;
+use Kirby\Cms\App as Kirby;
 
 require_once __DIR__ . '/media.class.php';
 require_once __DIR__ . '/class.php';

--- a/media.class.php
+++ b/media.class.php
@@ -17,7 +17,10 @@ Kirby::plugin('d4l/static-site-generator-media', [
         return $version;
       }
 
-      $version->save();
+      if (!$version->exists()) {
+        $version->save();
+      }
+
       StaticSiteGeneratorMedia::register($version->root(), $version->url());
       return $version;
     },


### PR DESCRIPTION
## Description

⚡️ Significantly improve rebuild performance by skipping regenerating media that is already generated in the required version.

## Motivation

Speed up the plugin when repeatedly used.

## Testing

The change was only tested locally and when generating via class method. Endpoint and field usage are untested, but there is no indication that they'd work differently.

## Related issue

--