### PR TITLE
✨ support multilang kirby collections

### DIFF
--- a/class.php
+++ b/class.php
@@ -106,6 +106,8 @@ class StaticSiteGenerator
 
   protected function _setPageLanguage(Page $page, string $languageCode = null)
   {
+    $this->_resetCollections();
+
     $kirby = $this->_kirby;
     $site = $kirby->site();
     $pages = $site->index();
@@ -124,6 +126,12 @@ class StaticSiteGenerator
 
     $kirby->cache('pages')->flush();
     $site->visit($page, $languageCode);
+  }
+
+  protected function _resetCollections() {
+    (function() {
+      $this->collections = null;
+    })->bindTo($this->_kirby, 'Kirby\\Cms\\App')($this->_kirby);
   }
 
   protected function _generatePage(Page $page, string $path, string $baseUrl)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
## Description

In multi-language setups, the pages returned by Kirby's [collection](https://getkirby.com/docs/guide/templates/collections) feature can differ by language. However, Kirby caches the collections, so it's necessary to reset them when changing the language.
