### PR TITLE
✨ support custom .html routes

### DIFF
--- a/class.php
+++ b/class.php
@@ -322,6 +322,7 @@ class StaticSiteGenerator
   protected function _cleanPath(string $path): string
   {
     $path = str_replace('//', '/', $path);
+    $path = preg_replace('/([^\/]+\.htm(l)?)\/index.html$/i', '$1', $path);
 
     if (strpos($path, '//') !== false) {
       return $this->_cleanPath($path);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!--- Please write a short summary of your changes here -->

## Description

Support custom `.html` routes in custom routes / urls. Previously, e.g. a custom route with `foo/bar.html` as a path would result in the following file being generated:
```
foo/bar.html/index.html
```
After this PR, `.htm(l)` at the end of a path is detected, leading to this file path:
```
foo/bar.html
```

This may hypothetically be a breaking change, so it comes as a minor and not a bugfix release.

## Motivation

fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/49

## Testing

Starterkit / static-site-generator field

## Related issue

https://github.com/d4l-data4life/kirby3-static-site-generator/issues/49