### PR TITLE
✨ Add configuration option custom_filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Alternatively, create a `static-site-generator` folder in `site/plugins`, downlo
 - Customizable output folder
 - Preserve individual files / folders in the output folder
 - Custom routes (click [here](#custom-routes) for more information)
+- Custom pages filtering (click [here](#custom-filters) for more information)
 
 ## What doesn't work
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ return [
         'skip_media' => false, # set to true to skip copying media files, e.g. when they are already on a CDN; combinable with 'preserve' => ['media']
         'skip_templates' => [], # ignore pages with given templates (home is always rendered)
         'custom_routes' => [] # see below for more information on custom routes
+        'custom_routes' => [] # see below for more information on custom filters
       ]
     ]
 ];
@@ -148,6 +149,35 @@ $staticSiteGenerator->setCustomRoutes($customRoutes);
 ```php
 'd4l.static_site_generator.custom_routes' => $customRoutes
 ```
+
+## Custom filters
+
+When using the endpoint or `static-site-generator` field, this plugin will by default render all pages and subpages (using page()->index()).
+You can filter the pages to be rendered by providing an array of custom filters in config option `custom_filters`.
+
+```php
+'d4l.static_site_generator.custom_filters' => $customFilters
+```
+
+Each element of this array must be an array of arguments accepted by [$pages->filterBy() method](https://getkirby.com/docs/cookbook/content/filtering).
+Here is an example array, showing some filters you could use (not exhaustive):
+
+```php
+$customFilters = [
+  [
+    ['slug', '==', 'foo'], // will not render the page if its slug is exactly 'foo'
+    ['url', '!*=', 'bar'], // will not render page if its url doesn't contains 'bar'
+    ['uri', '*', '/[1-9]/'], // will not render page if its uri doesn match regex '/[1-9]/'
+    ['depth', '>', '2'], // will not render page if its depth is greater than 2
+    ['dirname', 'in', ['foo', 'bar']] // will not render page if its dirname is in ['foo' or 'bar'],
+    ['category', 'bar'], // will not render page if its value in 'category' field is 'bar' ('category' being a single value field)
+    ['tags', 'bar', ','], // will not render page if its value in 'tags' field includes 'bar' ('tags' being a field accepting a comma separated list of values)
+    ['date', 'date <', '2018-01-01'], // will not render page if its date is before '2018-01-01'
+  ]
+];
+```
+
+⚠️ Here again, you can use [Kirby's `ready` option](https://getkirby.com/docs/reference/system/options/ready) to dynamically generate the custom filters.
 
 ## Warnings
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ return [
         'skip_media' => false, # set to true to skip copying media files, e.g. when they are already on a CDN; combinable with 'preserve' => ['media']
         'skip_templates' => [], # ignore pages with given templates (home is always rendered)
         'custom_routes' => [] # see below for more information on custom routes
-        'custom_routes' => [] # see below for more information on custom filters
+        'custom_filters' => [] # see below for more information on custom filters
       ]
     ]
 ];

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ $staticSiteGenerator->setCustomRoutes($customRoutes);
 
 ## Custom filters
 
-When using the endpoint or `static-site-generator` field, this plugin will by default render all pages and subpages (using page()->index()).
+When using the endpoint or `static-site-generator` field, this plugin will by default render all pages and subpages (using `page()->index()`).
 You can filter the pages to be rendered by providing an array of custom filters in config option `custom_filters`.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -152,19 +152,18 @@ $staticSiteGenerator->setCustomRoutes($customRoutes);
 
 ## Custom filters
 
-When using the endpoint or `static-site-generator` field, this plugin will by default render all pages and subpages (using `page()->index()`).
+When using the endpoint or `static-site-generator` field, this plugin will by default render all pages and subpages (using `pages()->index()`).
 You can filter the pages to be rendered by providing an array of custom filters in config option `custom_filters`.
 
 ```php
 'd4l.static_site_generator.custom_filters' => $customFilters
 ```
 
-Each element of this array must be an array of arguments accepted by [$pages->filterBy() method](https://getkirby.com/docs/cookbook/content/filtering).
+Each element of this array must be an array of arguments accepted by [`$pages->filterBy()` method](https://getkirby.com/docs/cookbook/content/filtering).
 Here is an example array, showing some filters you could use (not exhaustive):
 
 ```php
 $customFilters = [
-  [
     ['slug', '==', 'foo'], // will not render the page if its slug is exactly 'foo'
     ['url', '!*=', 'bar'], // will not render page if its url doesn't contains 'bar'
     ['uri', '*', '/[1-9]/'], // will not render page if its uri doesn match regex '/[1-9]/'
@@ -173,7 +172,6 @@ $customFilters = [
     ['category', 'bar'], // will not render page if its value in 'category' field is 'bar' ('category' being a single value field)
     ['tags', 'bar', ','], // will not render page if its value in 'tags' field includes 'bar' ('tags' being a field accepting a comma separated list of values)
     ['date', 'date <', '2018-01-01'], // will not render page if its date is before '2018-01-01'
-  ]
 ];
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",

--- a/index.php
+++ b/index.php
@@ -26,8 +26,13 @@ Kirby::plugin('d4l/static-site-generator', [
             $skipMedia = $kirby->option('d4l.static_site_generator.skip_media', false);
             $skipTemplates = array_diff($kirby->option('d4l.static_site_generator.skip_templates', []), ['home']);
             $customRoutes = $kirby->option('d4l.static_site_generator.custom_routes', []);
+						$customFilters = $kirby->option('d4l.static_site_generator.custom_filters', []);
 
             $pages = $kirby->site()->index()->filterBy('intendedTemplate', 'not in', $skipTemplates);
+						foreach ($customFilters as $filter) {
+							$pages = $pages->filterBy(...$filter);
+						}
+
             $staticSiteGenerator = new StaticSiteGenerator($kirby, null, $pages);
             $staticSiteGenerator->skipMedia($skipMedia);
             $staticSiteGenerator->setCustomRoutes($customRoutes);

--- a/index.php
+++ b/index.php
@@ -53,8 +53,8 @@ Kirby::plugin('d4l/static-site-generator', [
       'props' => [
         'endpoint' => function () {
           return $this->kirby()->option('d4l.static_site_generator.endpoint');
-        },
-      ],
-    ],
-  ],
+        }
+      ]
+    ]
+  ]
 ]);

--- a/index.php
+++ b/index.php
@@ -26,12 +26,15 @@ Kirby::plugin('d4l/static-site-generator', [
             $skipMedia = $kirby->option('d4l.static_site_generator.skip_media', false);
             $skipTemplates = array_diff($kirby->option('d4l.static_site_generator.skip_templates', []), ['home']);
             $customRoutes = $kirby->option('d4l.static_site_generator.custom_routes', []);
-						$customFilters = $kirby->option('d4l.static_site_generator.custom_filters', []);
+            $customFilters = $kirby->option('d4l.static_site_generator.custom_filters', []);
+            if (!empty($skipTemplates)) {
+              array_push($customFilters, ['intendedTemplate', 'not in', $skipTemplates]);
+            }
 
-            $pages = $kirby->site()->index()->filterBy('intendedTemplate', 'not in', $skipTemplates);
-						foreach ($customFilters as $filter) {
-							$pages = $pages->filterBy(...$filter);
-						}
+            $pages = $kirby->site()->index();
+            foreach ($customFilters as $filter) {
+              $pages = $pages->filterBy(...$filter);
+            }
 
             $staticSiteGenerator = new StaticSiteGenerator($kirby, null, $pages);
             $staticSiteGenerator->skipMedia($skipMedia);
@@ -50,8 +53,8 @@ Kirby::plugin('d4l/static-site-generator', [
       'props' => [
         'endpoint' => function () {
           return $this->kirby()->option('d4l.static_site_generator.endpoint');
-        }
-      ]
-    ]
-  ]
+        },
+      ],
+    ],
+  ],
 ]);


### PR DESCRIPTION
## Description

Add a configuration option 'custom_filters' to plugin.
It should work like 'skipTemplate' option while providing more skip/filtering methods.

Option should return an array of filters, matching [available Kirby page filter methods](https://getkirby.com/docs/reference/objects/cms/pages/filter-by#available-filter-methods) arguments (except dates related ones for now).

```php
// config.php

return [
    'd4l' => [
      'static_site_generator' => [
          'custom_filters' => [
              [$page_property, $filter_method, $value]
          ]
      ]
    ]
];
```
- $page_property being any static property of [Kirby\Cms\Page](https://github.com/getkirby/kirby/blob/3.6.6/src/Cms/Page.php)
- $filter_method matching [available Kirby page filter method](https://getkirby.com/docs/reference/objects/cms/pages/filter-by#available-filter-methods) (except dates related methods for now)
- $value being a string or array depending on filter method

Each filter will then be used to filter pages used for generation in d4l.static-site-generator api routes.

```php
// kirby3-static-site-generator/index.php

$customFilters = $kirby->option('d4l.static_site_generator.custom_filters', []);
$pages = $kirby->site()->index()->filterBy('intendedTemplate', 'not in', $skipTemplates);
foreach ($customFilters as $filter) {
    $pages = $pages->filterBy(...$filter);
}
```

#### Examples
```php
// config.php

'custom_filters' => [
    ['slug', '!*=', 'some_string'],
    ['dirname', '!*', 'some-regex'],
    ['uri', 'in', array()],
    ['blueprint', '!*=', 'some_string'],
    ['parent', '!^=', 'some_string],
];
```

## Motivation

When setting some routes in 'custom_routes' plugin option, for example `['path' => 'pagename', 'page' => 'folder/pagename']`, the page gets generated twice in `/static` folder (at `/static/folder/pagename/index.html` and `/static/pagename/index.html`).

When using endpoint or field method, we have no access to the $pages that get generated, and thus cannot prevent plugin from generating files in `/static/folder/`.

In conjonction to such 'custom_routes', 'custom_filters' option could help in matching Kirby's dynamic routing behavior, for example [Removing the parent page slug from the URL](https://getkirby.com/docs/guide/routing#removing-the-parent-page-slug-from-the-url).

#### Full use-case
```php
// config.php

<?php

/*
 * My content folder:
 * - 1_home
 * - 2_main
 *   - 1_page1
 *   - 2_page2
 * ...
 *
 * The 'main' page is only used to structure my content,
 * I don't want to be able to access it directly
 * nor it's slug to appear in URLs.
 */

$fantom_page = 'main'; // The page name I want to hide

return [

    /*
     * My dynamic routing
     */

    'routes' => [

        // Redirect 'main' page to homepage
        [
            'pattern' => $fantom_page,
            'action' => function () {
                go(page('home')->uid());
            },
        ],

        // Remove 'main' from its children urls
        [
            'pattern' => $fantom_page . '/(:all)',
            'action' => function ($uid) {
                go($uid);
            },
        ],

        // Redirect 'main' children pages
        [
            'pattern' => '(:all)',
            'action' => function ($uid) use ($fantom_page) {
                if ($uid == '') {
                    $uid = 'home';
                }
                $page = page($uid) ?? page($fantom_page . '/' . $uid) ?? site()->errorPage();
                return site()->visit($page);
            },
        ],
    ],

    /*
     * Now I want to reproduce this behavior in my static website
     */

    'd4l.static_site_generator' => [

        'endpoint' => 'generate-static-site',

        'custom_filters' => [ // new option proposal
            ['url', '!*=', $fantom_page], // Do not generate 'main' children pages in output 'main' folder
        ],
    ],

    'ready' => function () use ($fantom_page) {

        $pages = site()->pages()->index();

        $custom_routes_input_filters = [
            ['slug', '!=', $fantom_page], // Do not take 'main' page as an input
            ['url', '*=', $fantom_page], // Take every 'main' children as 'custom_routes' option value
        ];

        foreach ($custom_routes_input_filters as $filter) {
            $pages = $pages->filterBy(...$filter);
        }

        return [

            'd4l.static_site_generator' => [
                'custom_routes' => A::map(
                    $pages->toArray(),
                    function ($page) use ($fantom_page) { // Generate 'main' children at output root
                        $page = $page['uri'];
                        $path = Str::replace($page, $fantom_page . '/', '');
                        return compact('path', 'page');
                    }
                ),
            ],
        ];
    },
];
```

## Possible enhancements
- Should be able to work with date filters with some rework
- Could be useless if we could pass the $pages list in plugin via Kirby 'ready' options ?
- There are probably more clever ways to handle my use case without touching the plugin or with other proposals, but I thought the ability to filter pages not only with skipTemplate could be useful, is there any reason why it would be a bad idea ? (performance ?)

## Testing
Tested with the two endpoints method 
