### PR TITLE
🐛 fix page translations in multi-language + cli context

### DIFF
--- a/class.php
+++ b/class.php
@@ -97,7 +97,8 @@ class StaticSiteGenerator
     $this->_skipCopyingMedia = $skipCopyingMedia;
   }
 
-  public function setCustomRoutes(array $customRoutes) {
+  public function setCustomRoutes(array $customRoutes)
+  {
     $this->_customRoutes = $customRoutes;
   }
 
@@ -117,8 +118,9 @@ class StaticSiteGenerator
     }
   }
 
-  protected function _modifyBaseUrl(string $baseUrl) {
-    $urls = array_map(function($url) use ($baseUrl) {
+  protected function _modifyBaseUrl(string $baseUrl)
+  {
+    $urls = array_map(function ($url) use ($baseUrl) {
       $newUrl = $url === '/' ? $baseUrl : $baseUrl . $url;
       return strpos($url, 'http') === 0 ? $url : $newUrl;
     }, $this->_kirby->urls()->toArray());
@@ -169,6 +171,11 @@ class StaticSiteGenerator
     $site = $kirby->site();
     $pages = $site->index();
 
+    $page->content = null;
+    foreach ($page->files() as $file) {
+      $file->content = null;
+    }
+
     foreach ($pages as $pageItem) {
       $pageItem->content = null;
       foreach ($pageItem->files() as $file) {
@@ -185,8 +192,9 @@ class StaticSiteGenerator
     $site->visit($page, $languageCode);
   }
 
-  protected function _resetCollections() {
-    (function() {
+  protected function _resetCollections()
+  {
+    (function () {
       $this->collections = null;
     })->bindTo($this->_kirby, 'Kirby\\Cms\\App')($this->_kirby);
   }
@@ -286,7 +294,7 @@ class StaticSiteGenerator
 
   protected function _getFileList(string $path, bool $recursively = false)
   {
-    $items = array_map(function($item) {
+    $items = array_map(function ($item) {
       return str_replace('/', DIRECTORY_SEPARATOR, $item);
     }, Dir::read($path, [], true));
     if (!$recursively) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!--- Please write a short summary of your changes here -->

## Description

fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/57

## Motivation

Generated pages are not correctly rendered in their respective secondary languages in multi language + cli context. Turns out despite iterating over all pages, there is a remnant content cache attached to the local page object as a leftover from a previous render.

## Testing

Generation via class + cli

## Related issue

https://github.com/d4l-data4life/kirby3-static-site-generator/issues/57
