### PR TITLE
✨ support dynamic routes when called from custom routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternatively, create a `static-site-generator` folder in `site/plugins`, downlo
 
 ## What doesn't work
 
-- Dynamic routes
+- Dynamic routes (unless when called by custom route - click [here](#custom-routes) for more information)
 - Query parameters (unless processed by javascript)
 - Redirections / `die` or `exit` in the code (this also affects the compatibility with some other plugins)
 - Directly opening the html files in the browser with the file protocol (absolute base url `/`)
@@ -103,17 +103,24 @@ error: Custom error message
 
 You can also use this plugin to render custom routes. This way, e.g. paginations can be created programmatically.
 
-Custom routes are passed as an array. Each item must contain `path` and `page` properties.
+Custom routes are passed as an array. Each item must contain at least a `path` property and if the path does not match a route, either the `page` or `route` property must be set.
 
 Here is an example array, showing the different configuration options:
 
 ```php
 $customRoutes = [
-  [ // minimal configuration
+  [ // minimal configuration to render a route (must match, else skipped)
+    'path' => 'my/route',
+  ],
+  [ // minimal configuration to render a page
     'path' => 'foo/bar',
     'page' => 'some-page-id'
   ],
-  [ // advanced configuration
+  [ // advanced configuration to render a route (write to different path)
+    'path' => 'sitemap.xml',
+    'route' => 'my/sitemap/route'
+  ],
+  [ // advanced configuration to render a page
     'path' => 'foo/baz',
     'page' => page('some-page-id'),
     'languageCode' => 'en',
@@ -124,6 +131,8 @@ $customRoutes = [
   ]
 ];
 ```
+
+Only `GET` routes are supported. Patterns and action arguments are supported.
 
 `page` is provided as a string containing the page ID, or as a page object.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $customRoutes = [
 ];
 ```
 
-Only `GET` routes are supported. Patterns and action arguments are supported.
+Only `GET` routes without `language` scope are supported (you can of course add multiple custom routes for multiple languages). Patterns and action arguments are supported.
 
 `page` is provided as a string containing the page ID, or as a page object.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
## Description

This PR supports the rendering of Kirby routes when passed into the custom routes array.

## Motivation

Over time it was requested multiple times to support rendering dynamic routes.

## Testing

starterkit / field

## Related issue

fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/62
fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/59
