### PR TITLE
Add a flag to ignore untranslated pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ return [
         'skip_templates' => [], # ignore pages with given templates (home is always rendered)
         'custom_routes' => [], # see below for more information on custom routes
         'custom_filters' => [], # see below for more information on custom filters
-        'ignoreUntranslatedPages' => false # set to true to ignore pages without an own language
+        'ignore_untranslated_pages' => false # set to true to ignore pages without an own language
       ]
     ]
 ];

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ return [
         'base_url' => '/', # if the static site is not mounted to the root folder of your domain, change accordingly here
         'skip_media' => false, # set to true to skip copying media files, e.g. when they are already on a CDN; combinable with 'preserve' => ['media']
         'skip_templates' => [], # ignore pages with given templates (home is always rendered)
-        'custom_routes' => [] # see below for more information on custom routes
-        'custom_filters' => [] # see below for more information on custom filters
+        'custom_routes' => [], # see below for more information on custom routes
+        'custom_filters' => [], # see below for more information on custom filters
+        'ignoreUntranslatedPages' => false # set to true to ignore pages without an own language
       ]
     ]
 ];

--- a/class.php
+++ b/class.php
@@ -24,6 +24,7 @@ class StaticSiteGenerator
   protected $_originalBaseUrl;
   protected $_defaultLanguage;
   protected $_languages;
+  protected $_ignoreUntranslatedPages;
 
   protected $_skipCopyingMedia = false;
 
@@ -102,6 +103,11 @@ class StaticSiteGenerator
     $this->_customRoutes = $customRoutes;
   }
 
+  public function setIgnoreUntranslatedPages(bool $ignoreUntranslatedPages = null)
+  {
+    $this->_ignoreUntranslatedPages = $ignoreUntranslatedPages;
+  }
+
   protected function _setOriginalBaseUrl()
   {
     if (!$this->_kirby->urls()->base()) {
@@ -131,13 +137,15 @@ class StaticSiteGenerator
   {
     foreach ($this->_pages->keys() as $key) {
       $page = $this->_pages->$key;
-      $this->_setPageLanguage($page, $languageCode);
-      $path = str_replace($this->_originalBaseUrl, '/', $page->url());
-      $path = $this->_cleanPath($this->_outputFolder . $path . '/index.html');
-      try {
-        $this->_generatePage($page, $path, $baseUrl);
-      } catch (ErrorException $error) {
-        $this->_handleRenderError($error, $key, $languageCode);
+      if(!$this->_ignoreUntranslatedPages || $page->translation($languageCode)->exists()){
+        $this->_setPageLanguage($page, $languageCode);
+        $path = str_replace($this->_originalBaseUrl, '/', $page->url());
+        $path = $this->_cleanPath($this->_outputFolder . $path . '/index.html');
+        try {
+          $this->_generatePage($page, $path, $baseUrl);
+        } catch (ErrorException $error) {
+          $this->_handleRenderError($error, $key, $languageCode);
+        }
       }
     }
   }

--- a/class.php
+++ b/class.php
@@ -24,7 +24,7 @@ class StaticSiteGenerator
   protected $_originalBaseUrl;
   protected $_defaultLanguage;
   protected $_languages;
-  protected $_ignoreUntranslatedPages;
+  protected $_ignoreUntranslatedPages = false;
 
   protected $_skipCopyingMedia = false;
 
@@ -103,7 +103,7 @@ class StaticSiteGenerator
     $this->_customRoutes = $customRoutes;
   }
 
-  public function setIgnoreUntranslatedPages(bool $ignoreUntranslatedPages = null)
+  public function setIgnoreUntranslatedPages(bool $ignoreUntranslatedPages)
   {
     $this->_ignoreUntranslatedPages = $ignoreUntranslatedPages;
   }
@@ -137,15 +137,17 @@ class StaticSiteGenerator
   {
     foreach ($this->_pages->keys() as $key) {
       $page = $this->_pages->$key;
-      if(!$this->_ignoreUntranslatedPages || $page->translation($languageCode)->exists()){
-        $this->_setPageLanguage($page, $languageCode);
-        $path = str_replace($this->_originalBaseUrl, '/', $page->url());
-        $path = $this->_cleanPath($this->_outputFolder . $path . '/index.html');
-        try {
-          $this->_generatePage($page, $path, $baseUrl);
-        } catch (ErrorException $error) {
-          $this->_handleRenderError($error, $key, $languageCode);
-        }
+      if($this->_ignoreUntranslatedPages && !$page->translation($languageCode)->exists()){
+        continue;
+      }
+
+      $this->_setPageLanguage($page, $languageCode);
+      $path = str_replace($this->_originalBaseUrl, '/', $page->url());
+      $path = $this->_cleanPath($this->_outputFolder . $path . '/index.html');
+      try {
+        $this->_generatePage($page, $path, $baseUrl);
+      } catch (ErrorException $error) {
+        $this->_handleRenderError($error, $key, $languageCode);
       }
     }
   }

--- a/index.php
+++ b/index.php
@@ -27,6 +27,7 @@ Kirby::plugin('d4l/static-site-generator', [
             $skipTemplates = array_diff($kirby->option('d4l.static_site_generator.skip_templates', []), ['home']);
             $customRoutes = $kirby->option('d4l.static_site_generator.custom_routes', []);
             $customFilters = $kirby->option('d4l.static_site_generator.custom_filters', []);
+            $ignoreUntranslatedPages = $kirby->option('d4l.static_site_generator.ignoreUntranslatedPages', false);
             if (!empty($skipTemplates)) {
               array_push($customFilters, ['intendedTemplate', 'not in', $skipTemplates]);
             }
@@ -39,6 +40,7 @@ Kirby::plugin('d4l/static-site-generator', [
             $staticSiteGenerator = new StaticSiteGenerator($kirby, null, $pages);
             $staticSiteGenerator->skipMedia($skipMedia);
             $staticSiteGenerator->setCustomRoutes($customRoutes);
+            $staticSiteGenerator->setIgnoreUntranslatedPages($ignoreUntranslatedPages);
             $list = $staticSiteGenerator->generate($outputFolder, $baseUrl, $preserve);
             $count = count($list);
             return ['success' => true, 'files' => $list, 'message' => "$count files generated / copied"];


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!--- Please write a short summary of your changes here -->

Add a flag to ignore untranslated pages. 

## Description
I add a flag to ignore pages without an own language. 

For example: 
So if you have 3 langages defined in kirby, but your page is only available in 2.
If you set the flag on true the page should only generate in the 2 languages. 
If the flag is false, the page should generate in 3 language, with 2 duplicates. 

<!--- Describe your changes in detail -->

## Motivation
We do not want to have the same html file in several directions for our website.
To generate the pages and then delete the unnessary ones manually, is not a good way, so 

<!--- Why this change? What problem does it solve? -->

## Testing
I tested it with the flag on and off in the three ways of the plugin.

<!--- What did you test? -->
<!--- Did you test all three ways to use the plugin with your change? -->
