### PR TITLE
✨ support page context in route rendering to allow for advanced pagination use cases, set current path to support pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ $customRoutes = [
     'path' => 'foo/bar',
     'page' => 'some-page-id'
   ],
+  [ // render a route with a page + language context (e.g. for pagination)
+    'path' => 'de/notes/2',
+    'page' => 'notes',
+    'route' => 'ssg/notes/page:2',
+    'languageCode' => 'de',
+  ],
   [ // advanced configuration to render a route (write to different path)
     'path' => 'sitemap.xml',
     'route' => 'my/sitemap/route'

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
## Description

Support pagination use cases by providing an option to attach a page context as well as setting the current url context (required for rendering pagination links correctly)

## Motivation

fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/72
fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/73
fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/71
fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/64

## Testing

Single and multi-language, with and without custom routes, panel field

