### PR TITLE
🐛 setPageLanguage: reset pages/site also for virtual translated pages

### DIFF
--- a/class.php
+++ b/class.php
@@ -212,11 +212,11 @@ class StaticSiteGenerator
     }
 
     $path = $this->_cleanPath($this->_outputFolder . '/' . $path . '/' . $this->_indexFileName);
-    $this->_setPageLanguage($page, $languageCode, $page->exists());
+    $this->_setPageLanguage($page, $languageCode, false);
     $this->_generatePage($page, $path, $baseUrl, $data, $routeContent);
   }
 
-  protected function _setPageLanguage(Page $page, string $languageCode = null, $reset = true)
+  protected function _setPageLanguage(Page $page, string $languageCode = null, $forceReset = true)
   {
     $this->_resetCollections();
 
@@ -224,23 +224,23 @@ class StaticSiteGenerator
     $site = $kirby->site();
     $pages = $site->index();
 
-    if ($reset) {
+    if ($page->exists() || $forceReset) {
       $page->content = null;
       foreach ($page->files() as $file) {
         $file->content = null;
       }
+    }
 
-      foreach ($pages as $pageItem) {
-        $pageItem->content = null;
-        foreach ($pageItem->files() as $file) {
-          $file->content = null;
-        }
-      }
-
-      $site->content = null;
-      foreach ($site->files() as $file) {
+    foreach ($pages as $pageItem) {
+      $pageItem->content = null;
+      foreach ($pageItem->files() as $file) {
         $file->content = null;
       }
+    }
+
+    $site->content = null;
+    foreach ($site->files() as $file) {
+      $file->content = null;
     }
 
     $kirby->cache('pages')->flush();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "d4l/kirby-static-site-generator",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "kirby-plugin",
   "description": "Static site generator plugin for Kirby 3",
   "license": "MIT",


### PR DESCRIPTION
## Description

fixes https://github.com/d4l-data4life/kirby3-static-site-generator/issues/81

## Motivation

https://github.com/d4l-data4life/kirby3-static-site-generator/issues/81

## Testing

Direct class method

## Related issue

https://github.com/d4l-data4life/kirby3-static-site-generator/issues/81
