### PR TITLE
Update class.php

### DIFF
--- a/class.php
+++ b/class.php
@@ -213,7 +213,7 @@ class StaticSiteGenerator
     }
 
     $path = $this->_cleanPath($this->_outputFolder . '/' . $path . '/' . $this->_indexFileName);
-    $this->_setPageLanguage($page, $languageCode, false);
+    $this->_setPageLanguage($page, $languageCode);
     $this->_generatePage($page, $path, $baseUrl, $data, $routeContent);
   }
 


### PR DESCRIPTION
Fixed Virtual Pages content Translation Issue

class.php changed:
$this->_setPageLanguage($page, $languageCode, false); to $this->_setPageLanguage($page, $languageCode); 
as it now properly sets the languages for Virtual Pages

## Description/Motivation

So I Stumbled upon a Problem generation our Multipage project. We have a few Plugins That use Virtual Pages and Multi Language Support now I created a script to load the Pages into the static site generator. It works fine, but the Translations didn't seem to work.  I debugged a little bit and this was the first working version.

## Testing

So I just tested it With a Script and Custom Routes.

## Related issue

New
